### PR TITLE
Change class token to "class"

### DIFF
--- a/lib/plates.js
+++ b/lib/plates.js
@@ -346,7 +346,7 @@ var Plates = (typeof process !== 'undefined' && typeof process.title !== 'undefi
       return last.call(this) && this;
     },
 
-    class: function(val) {
+    "class": function(val) {
       return this.where('class').is(val);
     },
     tag: function(val) {


### PR DESCRIPTION
`class` as an identifier in a object literal is not valid in ES3.

Changing it to the string `"class"` gives better ES3 support. 
