### PR TITLE
Improve IE 8/7 compatibility

### DIFF
--- a/lib/plates.js
+++ b/lib/plates.js
@@ -303,7 +303,7 @@ var Plates = (typeof process !== 'undefined' && typeof process.title !== 'undefi
 
   };
 
-  var Mapper = function Mapper(conf) {
+  var Mapper = function (conf) {
     if (!(this instanceof Mapper)) { return new Mapper(conf); }
     this.mappings = [];
     this.conf = conf || {};


### PR DESCRIPTION
If plates.js is minified and variable names rewritten, IE 8 and below run into issues when instantiating a Mapper. It seems that if the variable that holds the constructor (re-written) and the constructor name itself differ, the methods in the prototype don't get copied into the instance. Solved by not using the function declaration style.

Using `string.charAt(i)` instead of `string[i]` seems to help quite a bit in improving compatibility with IE 7. The semantics of the bracket notation and charAt should be identical in browsers that support brackets. The performance of both is comparable, except for Firefox 9+ where charAt is substantially faster.

http://jsperf.com/string-charat-vs-bracket-notation
