### PR TITLE
[api] Check for CommonJS compatibility instead of `process`

### DIFF
--- a/lib/plates.js
+++ b/lib/plates.js
@@ -1,4 +1,4 @@
-var Plates = (typeof process !== 'undefined' && typeof process.title !== 'undefined') ? exports : {};
+var Plates = (typeof module !== 'undefined' && typeof module.exports !== 'undefined' && typeof exports !== 'undefined') ? exports : {};
 
 !function(exports) {
 


### PR DESCRIPTION
This allows Plates to work in CommonJS implementations besides node.js.
