### PR TITLE
[dist] update mustache version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "devDependencies": {
     "vows": "0.6.x",
-    "mustache": "0.3.x",
+    "mustache": "0.4.x",
     "benchmark": "0.2.x"
   },
   "scripts": {


### PR DESCRIPTION
Hi

After have been running a lot of benchmarks on my [domstream](http://github.com/AndreasMadsen/domstream) module I discovered a little paradox in competition results. It turned out that plates compare to mustach `0.3.x` however `0.4.x` is significant faster. The end result is that mustach do actually beat both domstream and plates.

I have no shame in life, I hope the same goes for the nodejitsu people.

_Note: I'm not a competitive being so I did not include domstream in your benchmark, however you are of course wellcome to do so._

**TL;TR**
Updates muctach version, it is significant faster.
