### PR TITLE
[fix] Run in strict mode, and fix strict mode violations

### DIFF
--- a/lib/plates.js
+++ b/lib/plates.js
@@ -1,6 +1,7 @@
 var Plates = (typeof module !== 'undefined' && typeof module.exports !== 'undefined' && typeof exports !== 'undefined') ? exports : {};
 
 !function(exports) {
+  "use strict";
 
   var _toString = Object.prototype.toString,
       isArray = Array.isArray || function (o) {
@@ -197,10 +198,10 @@ var Plates = (typeof module !== 'undefined' && typeof module.exports !== 'undefi
                   else if (!mappings[ii].replace && mappings[ii].attribute === key) {
 
                     if (
-                      mappings[ii].value === value || 
-                      that.hasClass(value, mappings[ii].value || 
+                      mappings[ii].value === value ||
+                      that.hasClass(value, mappings[ii].value ||
                       mappings.conf.where === key) ||
-                      ( ({}).toString.call(mappings[ii].value) === '[object RegExp]' && 
+                      ( ({}).toString.call(mappings[ii].value) === '[object RegExp]' &&
                         mappings[ii].value.exec(value) !== null) ) {
 
                       var v = data[mappings[ii].dataKey];
@@ -213,7 +214,7 @@ var Plates = (typeof module !== 'undefined' && typeof module.exports !== 'undefi
                         // If the item is an array, then we need to tell
                         // Plates that we're dealing with nests
                         that.nest.push(tagname);
-                      } 
+                      }
                       else if (typeof v === 'object') {
 
                         newdata = tagbody + that.iterate(html, v, components, tagname, value);
@@ -310,7 +311,7 @@ var Plates = (typeof module !== 'undefined' && typeof module.exports !== 'undefi
   };
 
   function last(newitem) {
-    
+
     if (newitem) {
 
       this.mappings.push({});
@@ -319,10 +320,9 @@ var Plates = (typeof module !== 'undefined' && typeof module.exports !== 'undefi
 
     if (m && m.attribute && m.value && m.dataKey && m.replace) {
       m.re = new RegExp(m.attribute + '=([\'"]?)' + m.value + '\\1');
-    
-    } else {
-    
-      delete m && m.re;
+
+    } else if (m) {
+      delete m.re;
     }
     return m;
   }


### PR DESCRIPTION
This allows Plates to be used in environments that use strict mode.
It passes all API tests.

Also, the redundant whitespace was automatically removed by VIM.
