### PR TITLE
Fix for failing browser tests

### DIFF
--- a/test/browser.html
+++ b/test/browser.html
@@ -607,7 +607,7 @@ var common = {
 
     var result = Plates.bind(html, data, map);
 
-    assert.equal(
+    QUnit.assert.equal(
         result.trim().replace(/[\n|\r]/g, '')
       , out.trim().replace(/[\n|\r]/g, '')
       , 'Expecting `' + html + '` to equal `' + out + '`'


### PR DESCRIPTION
All browser tests are failing with the used QUnit (http://code.jquery.com/qunit/qunit-git.js) as 'assert' is assumed to be global, which it seems not to be since version 1.11.0. (After this fix only two tests are failing.)
