### PR TITLE
Fix for attributes containing = and ' but without ids

### DIFF
--- a/lib/plates.js
+++ b/lib/plates.js
@@ -140,7 +140,8 @@ function matchClosing(input, tagname, html) {
     //
     // HTML attribute parser.
     //
-    attr: /([\-\w]*)\s*=\s*(?:(["\'])([\-\.\w\s\/:;&#]*)\2)/gi,
+    // attr: /([\-\w]*)\s*=\s*(?:(["\'])([\-\.\w\s\/:;&#]*)\2)/gi,
+    attr: /([\-\w]*)\s*=\s*(?:(["\'])([^\2]*?)\2|((\w*)))/gi,
 
     //
     // In HTML5 it's allowed to have to use self closing tags without closing

--- a/lib/plates.js
+++ b/lib/plates.js
@@ -140,7 +140,6 @@ function matchClosing(input, tagname, html) {
     //
     // HTML attribute parser.
     //
-    // attr: /([\-\w]*)\s*=\s*(?:(["\'])([\-\.\w\s\/:;&#]*)\2)/gi,
     attr: /([\-\w]*)\s*=\s*(?:(["\'])([^\2]*?)\2|((\w*)))/gi,
 
     //

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plates",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Unobtrusive templating for the flatiron framework",
   "keywords": [
     "templates",

--- a/test/fixtures/test-43.html
+++ b/test/fixtures/test-43.html
@@ -1,4 +1,5 @@
 <div>
   <div id="include" data-ng-include="'path/to/partial'"></div>
   <div id="show" data-ng-show="svc.prop == 'val'"></div>
+  <div data-ng-show="tabSvc.tab == 'locations'">Don't Touch Me</div>
 </div>

--- a/test/fixtures/test-43.out
+++ b/test/fixtures/test-43.out
@@ -1,4 +1,5 @@
 <div>
   <div id="include" data-ng-include="'path/to/partial'">Include</div>
   <div id="show" data-ng-show="svc.prop == 'val'">Show</div>
+  <div data-ng-show="tabSvc.tab == 'locations'">Don't Touch Me</div>
 </div>


### PR DESCRIPTION
This furthers compatibility with AngularJS style tags.  Tags that were not being modified were being incorrectly parsed if they contained a pattern such as <tag attr="something == 'else'">