### PR TITLE
[Browserify support] Sets module.exports now, in addition to exports

### DIFF
--- a/lib/plates.js
+++ b/lib/plates.js
@@ -664,3 +664,7 @@ function matchClosing(input, tagname, html) {
   //
   exports.Map = Mapper;
 }(Plates, this);
+
+if (module && module.exports) {
+  module.exports = Plates;
+}


### PR DESCRIPTION
Setting the value of "exports" alone won't expose required properties, an empty object ({}) will be returned. Browserify expects 'module.exports', this fixes the issue.
