### PR TITLE
[Browserify support] Sets module.exports now, in addition to exports

### DIFF
--- a/lib/plates.js
+++ b/lib/plates.js
@@ -664,3 +664,7 @@ function matchClosing(input, tagname, html) {
   //
   exports.Map = Mapper;
 }(Plates, this);
+
+if (module && module.exports) {
+  module.exports = Plates;
+}

--- a/lib/plates.js
+++ b/lib/plates.js
@@ -665,6 +665,6 @@ function matchClosing(input, tagname, html) {
   exports.Map = Mapper;
 }(Plates, this);
 
-if (module && module.exports) {
+if (typeof(module) !== 'undefined' && 'exports' in module) {
   module.exports = Plates;
 }


### PR DESCRIPTION
Now has proper type checking for usage in browsers, will not throw an exception if module.exports is missing. 