### PR TITLE
Handle Boolean attributes (e.g. 'checked', 'selected')

### DIFF
--- a/lib/plates.js
+++ b/lib/plates.js
@@ -341,8 +341,8 @@ function matchClosing(input, tagname, html) {
                     // 
                     // remove a Boolean attribute if the value evaluates to false
                     //
-                    if (Merge.prototype.booleanAttr.indexOf(key.toLowerCase()) != -1) {
-                      return !newdata ? '' : key + '="' + key + '"';
+                    if (!newdata && Merge.prototype.booleanAttr.indexOf(key.toLowerCase()) != -1) {
+                      return '';
                     }
 
                     return key + '="' + (newdata || '') + '"';

--- a/lib/plates.js
+++ b/lib/plates.js
@@ -147,7 +147,17 @@ function matchClosing(input, tagname, html) {
     // separators. So we need to detect these elements based on the tag name.
     //
     selfClosing: /^(area|base|br|col|command|embed|hr|img|input|keygen|link|meta|param|source|track|wbr)$/,
-
+    
+    //
+    // Boolean Attributes - attributes that require no value
+    //
+    booleanAttr: ['allowfullscreen','async','autofocus','autoplay','checked','compact','controls',
+        'declare','default','defaultchecked','defaultmuted','defaultselected','defer','disabled',
+        'draggable','enabled','formnovalidate','hidden','indeterminate','inert','ismap','itemscope',
+        'loop','multiple','muted','nohref','noresize','noshade','novalidate','nowrap','open',
+        'pauseonexit','readonly','required','reversed','scoped','seamless','selected','sortable',
+        'spellcheck','translate','truespeed','typemustmatch','visible'],
+    
     //
     // ### function hasClass(str, className)
     // #### @str {String} the class attribute
@@ -326,6 +336,13 @@ function matchClosing(input, tagname, html) {
                       newdata = value.replace(mapping.replacePartial1, fetch(data, mapping, value, tagbody, key));
                     } else {
                       newdata = fetch(data, mapping, value, tagbody, key);
+                    }
+  
+                    // 
+                    // remove a Boolean attribute if the value evaluates to false
+                    //
+                    if (Merge.prototype.booleanAttr.indexOf(key.toLowerCase()) != -1) {
+                      return !newdata ? '' : key + '="' + key + '"';
                     }
 
                     return key + '="' + (newdata || '') + '"';


### PR DESCRIPTION
Currently when trying to map the 'checked' state of a checkbox, Platesjs will always check the checkbox, regardless of the 'checked' value being provided. This is because Platesjs requires all mapped elements to be part of the template and the html spec specifies that Boolean attributes such as 'checked' merely have to be present on the element to perform their function.

This simple PR fixes the issue by effectively removing Boolean attributes from the element in question if the mapped value evaluates to false.

For details:
http://www.w3.org/TR/html4/intro/sgmltut.html#h-3.3.4.2 
https://github.com/kangax/html-minifier/issues/63#issuecomment-37763316
